### PR TITLE
Remove scipy dependency and add fix for prepareAnnotatePdData function

### DIFF
--- a/ch/utils/fisher_exact_test.py
+++ b/ch/utils/fisher_exact_test.py
@@ -1,6 +1,5 @@
 import decimal
 import numpy as np
-from scipy.stats import fisher_exact
 from numba import njit
 
 # Fisher Test using fisher package (much faster)

--- a/ch/vdbtools/handlers/annotations.py
+++ b/ch/vdbtools/handlers/annotations.py
@@ -61,6 +61,7 @@ def prepareAnnotatePdData(df, vars, debug):
                   "%3D":"=", "=":"="}
 
     df['AAchange'] = df['HGVSp'].str.extract(r'(.*p\.)(.*)')[1]
+    df['AAchange'] = df['AAchange'].astype("string")
     df.replace({'AAchange': AminoAcids}, inplace=True, regex=True)
     df['loci_p'] = df["AAchange"].str.extract(r'(.[0-9]+)')
     df['gene_loci_p'] = df['SYMBOL']+"_"+df['loci_p']

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,5 @@ python-dateutil==2.8.2
 pytz==2023.3
 six==1.16.0
 tzdata==2023.3
-scipy==1.12.0
 llvmlite==0.42.0
 numba==0.59.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,6 @@ install_requires =
     duckdb==1.0.0
     pandas==2.0.0
     pysam==0.21.0
-    scipy==1.12.0
     llvmlite==0.42.0
     numba==0.59.0
 


### PR DESCRIPTION
- Remove the `scipy` dependency to minimize the risk of installation conflicts.
- Convert `AAchange` to `string` type to avoid errors. When there is nothing to extract from the `HGVSp` column, `AAchange` type is not set as `string`, which leads to errors in `df.place`. 